### PR TITLE
Update to mailchimp v2.0 api and handle api errors

### DIFF
--- a/lib/omniauth/strategies/mailchimp.rb
+++ b/lib/omniauth/strategies/mailchimp.rb
@@ -43,7 +43,15 @@ module OmniAuth
           data = user_data
           endpoint = data["api_endpoint"]
           apikey = "#{@access_token.token}-#{data['dc']}"
-          @access_token.get("#{endpoint}/2.0/helper/account-details?apikey=#{apikey}").parsed
+          response = @access_token.get("#{endpoint}/2.0/helper/account-details?apikey=#{apikey}").parsed
+          if response["error"]
+            case response["code"]
+            when 109
+              fail!(:invalid_credentials, response["error"])
+            end
+          else
+            response
+          end
         end
       end
 


### PR DESCRIPTION
When trying to authenticate as a restricted user (i.e. not owner or admin) the strategy blows up building the info hash since raw_info fails to get any data and returns nil.  This is due to mailchimp's restrictions on the helper/account-details api endpoint (http://apidocs.mailchimp.com/api/2.0/helper/account-details.php) which throws an error when accessed by restricted users.  This patch treats that as a failure to authenticate and calls fail!, allowing the consumer to handle it gracefully rather than throw a 500 or other error page.  I also updated the api call to use the new v2.0 api call since v1.3 is now deprecated.
