### PR TITLE
Continue working with MailChimp if contact not set

### DIFF
--- a/lib/omniauth/strategies/mailchimp.rb
+++ b/lib/omniauth/strategies/mailchimp.rb
@@ -24,10 +24,12 @@ module OmniAuth
       }
 
       info do
+        contact = raw_info["contact"] || {}
+
         {
-          :first_name => raw_info["contact"]["fname"],
-          :last_name => raw_info["contact"]["lname"],
-          :email => raw_info["contact"]["email"]
+          :first_name => contact["fname"],
+          :last_name => contact["lname"],
+          :email => contact["email"]
         }
       end
 


### PR DESCRIPTION
We had a few users who were apparently able to authorize with MailChimp before their MailChimp contact was set. I'm assuming this is someone who signs up as part of the OAuth flow.

The exception was your usual `method '[]' does not exist for nil:NilClass` because `raw_info["contact"]` was `null`.
