### PR TITLE
add api token with DC tag for convenience

### DIFF
--- a/lib/omniauth/strategies/mailchimp.rb
+++ b/lib/omniauth/strategies/mailchimp.rb
@@ -36,7 +36,8 @@ module OmniAuth
       extra do
         {
           :metadata => user_data,
-          :raw_info => raw_info
+          :raw_info => raw_info,
+          :api_token_with_dc => "#{@access_token.token}-#{user_data['dc']}",
         }
       end
 


### PR DESCRIPTION
Given that the Mailchimp API wrapper gem suggests use of API tokens with the DC attached, it's probably a good idea to include it in the extra section.